### PR TITLE
Prooph Event Store 5.0 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,8 @@ php:
   - 5.6
 
 env:
-  - DOCTRINE_VERSION=2.3.* ES_VERSION=3.*
-  - DOCTRINE_VERSION=2.4.* ES_VERSION=3.*
-  - DOCTRINE_VERSION=2.5.*@dev ES_VERSION=3.*
+  - DOCTRINE_VERSION=2.4.* ES_VERSION=dev-5.0-beta
+  - DOCTRINE_VERSION=^2.5 ES_VERSION=dev-5.0-beta
 
 before_script:
   - composer self-update

--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ The database structure depends on the [stream strategies](https://github.com/pro
 You can find example SQLs for MySql in the [scripts folder](https://github.com/prooph/event-store-doctrine-adapter/blob/master/scripts/)
 and an [example script](https://github.com/prooph/event-store-doctrine-adapter/blob/master/examples/create-schema.php) of how you can use the adapter to generate stream tables.
 
+Requirements
+------------
+- PHP >= 5.5
+- [Doctrine DBAL](https://github.com/doctrine/dbal) ^2.4
+- [Prooph Event Store](https://github.com/prooph/event-store) ^5.0
+
 License
 -------
 

--- a/composer.json
+++ b/composer.json
@@ -8,16 +8,21 @@
             "name": "Jan Sorgalla",
             "email": "jan.sorgalla@dotsunited.de",
             "homepage": "http://dotsunited.de"
+        },
+        {
+            "name": "Alexander Miertsch",
+            "email": "contact@prooph.de",
+            "homepage": "http://www.prooph.de/"
         }
     ],
     "require": {
         "php": ">=5.5",
-        "doctrine/dbal": "~2.1",
-        "zendframework/zend-serializer" : "~2.3",
-        "beberlei/assert": "~2.0"
+        "doctrine/dbal": "^2.4",
+        "beberlei/assert": "^2.0",
+        "prooph/common": "^3.3"
     },
     "require-dev": {
-        "prooph/event-store": "dev-master",
+        "prooph/event-store": "dev-5.0-beta",
         "phpunit/phpunit": "4.7.*",
         "fabpot/php-cs-fixer": "1.7.*",
         "satooshi/php-coveralls": "dev-master"
@@ -30,11 +35,6 @@
     "autoload-dev": {
         "psr-0": {
             "Prooph\\EventStoreTest\\": "vendor/prooph/event-store/tests/"
-        }
-    },
-    "extra": {
-        "branch-alias": {
-            "dev-master": "0.1-dev"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
         "php": ">=5.5",
         "doctrine/dbal": "^2.4",
         "beberlei/assert": "^2.0",
-        "prooph/common": "^3.3"
+        "prooph/common": "^3.3",
+        "container-interop/container-interop" : "~1.1"
     },
     "require-dev": {
         "prooph/event-store": "dev-5.0-beta",
@@ -33,7 +34,7 @@
         }
     },
     "autoload-dev": {
-        "psr-0": {
+        "psr-4": {
             "Prooph\\EventStoreTest\\": "vendor/prooph/event-store/tests/"
         }
     }

--- a/scripts/mysql-aggregate-type-stream-template.sql
+++ b/scripts/mysql-aggregate-type-stream-template.sql
@@ -4,7 +4,6 @@ CREATE TABLE IF NOT EXISTS `[shortclassname]_stream` (
   `event_id` varchar(36) COLLATE utf8_unicode_ci NOT NULL,
   `version` int(11) NOT NULL,
   `event_name` varchar(100) COLLATE utf8_unicode_ci NOT NULL,
-  `event_class` varchar(100) COLLATE utf8_unicode_ci NOT NULL,
   `payload` text COLLATE utf8_unicode_ci NOT NULL,
   `created_at` varchar(50) COLLATE utf8_unicode_ci NOT NULL,
   `aggregate_id` text COLLATE utf8_unicode_ci NOT NULL,

--- a/scripts/mysql-single-stream-default-schema.sql
+++ b/scripts/mysql-single-stream-default-schema.sql
@@ -2,7 +2,6 @@ CREATE TABLE IF NOT EXISTS `event_stream` (
   `event_id` varchar(36) COLLATE utf8_unicode_ci NOT NULL,
   `version` int(11) NOT NULL,
   `event_name` varchar(100) COLLATE utf8_unicode_ci NOT NULL,
-  `event_class` varchar(100) COLLATE utf8_unicode_ci NOT NULL,
   `payload` text COLLATE utf8_unicode_ci NOT NULL,
   `created_at` varchar(50) COLLATE utf8_unicode_ci NOT NULL,
   `aggregate_id` varchar(36) COLLATE utf8_unicode_ci NOT NULL,

--- a/src/Container/DoctrineEventStoreAdapterFactory.php
+++ b/src/Container/DoctrineEventStoreAdapterFactory.php
@@ -1,0 +1,77 @@
+<?php
+/*
+ * This file is part of the prooph/event-store-doctrine-adapter.
+ * (c) 2014-2015 prooph software GmbH <contact@prooph.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace Prooph\EventStore\Adapter\Doctrine\Container;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\DriverManager;
+use Interop\Container\ContainerInterface;
+use Prooph\Common\Messaging\FQCNMessageFactory;
+use Prooph\Common\Messaging\MessageConverter;
+use Prooph\Common\Messaging\MessageFactory;
+use Prooph\Common\Messaging\NoOpMessageConverter;
+use Prooph\EventStore\Adapter\Doctrine\DoctrineEventStoreAdapter;
+use Prooph\EventStore\Adapter\PayloadSerializer;
+use Prooph\EventStore\Exception\ConfigurationException;
+
+/**
+ * Class DoctrineEventStoreAdapterFactory
+ *
+ * @package Prooph\EventStore\Adapter\Doctrine\Container
+ * @author Alexander Miertsch <kontakt@codeliner.ws>
+ */
+final class DoctrineEventStoreAdapterFactory
+{
+    public function __invoke(ContainerInterface $container)
+    {
+        $config = $container->get('config');
+
+        if (!isset($config['prooph']['event_store']['adapter']['options'])) {
+            throw ConfigurationException::configurationError(
+                'Missing adapter options configuration in prooph event_store configuration'
+            );
+        }
+
+        $adapterOptions = $config['prooph']['event_store']['adapter']['options'];
+
+        $connection = null;
+
+        if (isset($adapterOptions['connection_alias']) && $container->has((string)$adapterOptions['connection_alias'])) {
+            $connection = $container->get($adapterOptions['connection_alias']);
+        }
+
+        if (null === $connection && isset($adapterOptions['connection']) && is_array($adapterOptions['connection'])) {
+            $connection = DriverManager::getConnection($adapterOptions['connection']);
+        }
+
+        if (! $connection instanceof Connection) {
+            throw ConfigurationException::configurationError(sprintf(
+                '%s was not able to locate or create a valid Doctrine\DBAL\Connection',
+                __CLASS__
+            ));
+        }
+
+        $messageFactory = $container->has(MessageFactory::class)
+            ? $container->get(MessageFactory::class)
+            : new FQCNMessageFactory();
+
+        $messageConverter = $container->has(MessageConverter::class)
+            ? $container->get(MessageConverter::class)
+            : new NoOpMessageConverter();
+
+        $payloadSerializer = $container->has(PayloadSerializer::class)
+            ? $container->get(PayloadSerializer::class)
+            : new PayloadSerializer\JsonPayloadSerializer();
+
+        $streamTableMap = isset($adapterOptions['stream_table_map'])
+            ? $adapterOptions['stream_table_map']
+            : [];
+
+        return new DoctrineEventStoreAdapter($connection, $messageFactory, $messageConverter, $payloadSerializer, $streamTableMap);
+    }
+}

--- a/src/Container/DoctrineEventStoreAdapterFactory.php
+++ b/src/Container/DoctrineEventStoreAdapterFactory.php
@@ -41,7 +41,7 @@ final class DoctrineEventStoreAdapterFactory
 
         $connection = null;
 
-        if (isset($adapterOptions['connection_alias']) && $container->has((string)$adapterOptions['connection_alias'])) {
+        if (isset($adapterOptions['connection_alias']) && $container->has($adapterOptions['connection_alias'])) {
             $connection = $container->get($adapterOptions['connection_alias']);
         }
 

--- a/src/DoctrineEventStoreAdapter.php
+++ b/src/DoctrineEventStoreAdapter.php
@@ -57,7 +57,7 @@ final class DoctrineEventStoreAdapter implements Adapter, CanHandleTransaction
     /**
      * @var array
      */
-    private $standardColumns = ['event_id', 'event_name', 'event_class', 'created_at', 'payload', 'version'];
+    private $standardColumns = ['event_id', 'event_name', 'created_at', 'payload', 'version'];
 
     /**
      * @param Connection $dbalConnection

--- a/src/DoctrineEventStoreAdapter.php
+++ b/src/DoctrineEventStoreAdapter.php
@@ -1,73 +1,83 @@
 <?php
-
+/*
+ * This file is part of the prooph/event-store-doctrine-adapter.
+ * (c) 2014-2015 prooph software GmbH <contact@prooph.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
 namespace Prooph\EventStore\Adapter\Doctrine;
 
 use Doctrine\DBAL\Connection;
-use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\Schema\Schema;
-use Prooph\Common\Messaging\DomainEvent;
+use Prooph\Common\Messaging\Message;
+use Prooph\Common\Messaging\MessageConverter;
+use Prooph\Common\Messaging\MessageFactory;
 use Prooph\EventStore\Adapter\Adapter;
-use Prooph\EventStore\Adapter\Exception\ConfigurationException;
 use Prooph\EventStore\Adapter\Feature\CanHandleTransaction;
+use Prooph\EventStore\Adapter\PayloadSerializer;
 use Prooph\EventStore\Exception\RuntimeException;
 use Prooph\EventStore\Stream\Stream;
 use Prooph\EventStore\Stream\StreamName;
-use Zend\Serializer\Serializer;
 
 /**
  * EventStore Adapter for Doctrine
  */
-class DoctrineEventStoreAdapter implements Adapter, CanHandleTransaction
+final class DoctrineEventStoreAdapter implements Adapter, CanHandleTransaction
 {
     /**
      * @var Connection
      */
-    protected $connection;
+    private $connection;
 
     /**
      * Custom sourceType to table mapping
      *
      * @var array
      */
-    protected $streamTableMap = [];
+    private $streamTableMap = [];
+
+    /**
+     * @var MessageFactory
+     */
+    private $messageFactory;
+
+    /**
+     * @var MessageConverter
+     */
+    private $messageConverter;
 
     /**
      * Serialize adapter used to serialize event payload
      *
-     * @var string|\Zend\Serializer\Adapter\AdapterInterface
+     * @var PayloadSerializer
      */
-    protected $serializerAdapter;
+    private $payloadSerializer;
 
     /**
      * @var array
      */
-    protected $standardColumns = ['event_id', 'event_name', 'event_class', 'created_at', 'payload', 'version'];
+    private $standardColumns = ['event_id', 'event_name', 'event_class', 'created_at', 'payload', 'version'];
 
     /**
-     * @param  array $configuration
-     * @throws \Prooph\EventStore\Adapter\Exception\ConfigurationException
+     * @param Connection $dbalConnection
+     * @param MessageFactory $messageFactory
+     * @param MessageConverter $messageConverter
+     * @param PayloadSerializer $payloadSerializer
+     * @param array $streamTableMap
      */
-    public function __construct(array $configuration)
+    public function __construct(
+        Connection $dbalConnection,
+        MessageFactory $messageFactory,
+        MessageConverter $messageConverter,
+        PayloadSerializer $payloadSerializer,
+        array $streamTableMap = [])
     {
-        if (!isset($configuration['connection'])) {
-            throw new ConfigurationException('DB connection configuration is missing');
-        }
-
-        if (isset($configuration['stream_table_map'])) {
-            $this->streamTableMap = $configuration['stream_table_map'];
-        }
-
-        $connection = $configuration['connection'];
-
-        if (!$connection instanceof Connection) {
-            $connection = DriverManager::getConnection($connection);
-        }
-
-        $this->connection = $connection;
-
-        if (isset($configuration['serializer_adapter'])) {
-            $this->serializerAdapter = $configuration['serializer_adapter'];
-        }
+        $this->connection = $dbalConnection;
+        $this->messageFactory = $messageFactory;
+        $this->messageConverter = $messageConverter;
+        $this->payloadSerializer = $payloadSerializer;
+        $this->streamTableMap = $streamTableMap;
     }
 
     /**
@@ -96,7 +106,7 @@ class DoctrineEventStoreAdapter implements Adapter, CanHandleTransaction
 
     /**
      * @param StreamName $streamName
-     * @param DomainEvent[] $streamEvents
+     * @param Message[] $streamEvents
      * @throws \Prooph\EventStore\Exception\StreamNotFoundException If stream does not exist
      * @return void
      */
@@ -123,7 +133,7 @@ class DoctrineEventStoreAdapter implements Adapter, CanHandleTransaction
      * @param StreamName $streamName
      * @param array $metadata
      * @param null|int $minVersion
-     * @return DomainEvent[]
+     * @return Message[]
      */
     public function loadEventsByMetadataFrom(StreamName $streamName, array $metadata, $minVersion = null)
     {
@@ -153,9 +163,7 @@ class DoctrineEventStoreAdapter implements Adapter, CanHandleTransaction
         $events = [];
 
         foreach ($stmt->fetchAll(\PDO::FETCH_ASSOC) as $eventData) {
-            $payload = Serializer::unserialize($eventData['payload'], $this->serializerAdapter);
-
-            $eventClass = $eventData['event_class'];
+            $payload = $this->payloadSerializer->unserializePayload($eventData['payload']);
 
             //Add metadata stored in table
             foreach ($eventData as $key => $value) {
@@ -164,16 +172,13 @@ class DoctrineEventStoreAdapter implements Adapter, CanHandleTransaction
                 }
             }
 
-            $events[] = $eventClass::fromArray(
-                [
-                    'uuid' => $eventData['event_id'],
-                    'name' => $eventData['event_name'],
-                    'version' => (int)$eventData['version'],
-                    'created_at' => $eventData['created_at'],
-                    'payload' => $payload,
-                    'metadata' => $metadata
-                ]
-            );
+            $events[] = $this->messageFactory->createMessageFromArray($eventData['event_name'], [
+                'uuid' => $eventData['event_id'],
+                'version' => (int)$eventData['version'],
+                'created_at' => $eventData['created_at'],
+                'payload' => $payload,
+                'metadata' => $metadata
+            ]);
         }
 
         return $events;
@@ -210,7 +215,6 @@ class DoctrineEventStoreAdapter implements Adapter, CanHandleTransaction
 
         $table->addColumn('version', 'integer');
         $table->addColumn('event_name', 'string', ['length' => 100]);
-        $table->addColumn('event_class', 'string', ['length' => 100]);
         $table->addColumn('payload', 'text');
         $table->addColumn('created_at', 'string', ['length' => 50]);
 
@@ -237,37 +241,12 @@ class DoctrineEventStoreAdapter implements Adapter, CanHandleTransaction
     }
 
     /**
-     * Insert an event
-     *
-     * @param StreamName $streamName
-     * @param DomainEvent $e
-     * @return void
-     */
-    protected function insertEvent(StreamName $streamName, DomainEvent $e)
-    {
-        $eventData = [
-            'event_id' => $e->uuid()->toString(),
-            'version' => $e->version(),
-            'event_name' => $e->messageName(),
-            'event_class' => get_class($e),
-            'payload' => Serializer::serialize($e->payload(), $this->serializerAdapter),
-            'created_at' => $e->createdAt()->format(\DateTime::ISO8601)
-        ];
-
-        foreach ($e->metadata() as $key => $value) {
-            $eventData[$key] = (string)$value;
-        }
-
-        $this->connection->insert($this->getTable($streamName), $eventData);
-    }
-
-    /**
      * Get table name for given stream name
      *
      * @param StreamName $streamName
      * @return string
      */
-    protected function getTable(StreamName $streamName)
+    public function getTable(StreamName $streamName)
     {
         if (isset($this->streamTableMap[$streamName->toString()])) {
             $tableName = $this->streamTableMap[$streamName->toString()];
@@ -283,10 +262,44 @@ class DoctrineEventStoreAdapter implements Adapter, CanHandleTransaction
     }
 
     /**
+     * @return Connection
+     */
+    public function getConnection()
+    {
+        return $this->connection;
+    }
+
+    /**
+     * Insert an event
+     *
+     * @param StreamName $streamName
+     * @param Message $e
+     * @return void
+     */
+    private function insertEvent(StreamName $streamName, Message $e)
+    {
+        $eventArr = $this->messageConverter->convertToArray($e);
+
+        $eventData = [
+            'event_id' => $eventArr['uuid'],
+            'version' => $eventArr['version'],
+            'event_name' => $eventArr['message_name'],
+            'payload' => $this->payloadSerializer->serializePayload($eventArr['payload']),
+            'created_at' => $eventArr['created_at']
+        ];
+
+        foreach ($eventArr['metadata'] as $key => $value) {
+            $eventData[$key] = (string)$value;
+        }
+
+        $this->connection->insert($this->getTable($streamName), $eventData);
+    }
+
+    /**
      * @param StreamName $streamName
      * @return string
      */
-    protected function getShortStreamName(StreamName $streamName)
+    private function getShortStreamName(StreamName $streamName)
     {
         $streamName = str_replace('-', '_', $streamName->toString());
         return implode('', array_slice(explode('\\', $streamName), -1));

--- a/tests/Container/DoctrineEventStoreAdapterFactoryTest.php
+++ b/tests/Container/DoctrineEventStoreAdapterFactoryTest.php
@@ -1,0 +1,172 @@
+<?php
+/*
+ * This file is part of the prooph/event-store-doctrine-adapter.
+ * (c) 2014-2015 prooph software GmbH <contact@prooph.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Date: 8/24/15 - 12:09 AM
+ */
+namespace Prooph\EventStoreTest\Adapter\Doctrine\Container;
+
+use Doctrine\DBAL\Connection;
+use Interop\Container\ContainerInterface;
+use Prooph\Common\Messaging\MessageConverter;
+use Prooph\Common\Messaging\MessageFactory;
+use Prooph\EventStore\Adapter\Doctrine\Container\DoctrineEventStoreAdapterFactory;
+use Prooph\EventStore\Adapter\Doctrine\DoctrineEventStoreAdapter;
+use Prooph\EventStore\Adapter\PayloadSerializer;
+use Prooph\EventStore\Stream\StreamName;
+use Prooph\EventStoreTest\TestCase;
+
+final class DoctrineEventStoreAdapterFactoryTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_creates_an_adapter_using_configured_connection_alias()
+    {
+        $connection = $this->prophesize(Connection::class);
+
+        $config['prooph']['event_store']['adapter']['options']['connection_alias'] = 'app_dbal_connection';
+
+        $container = $this->prophesize(ContainerInterface::class);
+
+        $container->has('config')->willReturn(true);
+        $container->get('config')->willReturn($config);
+        $container->has('app_dbal_connection')->willReturn(true);
+        $container->get('app_dbal_connection')->willReturn($connection->reveal());
+        $container->has(MessageFactory::class)->willReturn(false);
+        $container->has(MessageConverter::class)->willReturn(false);
+        $container->has(PayloadSerializer::class)->willReturn(false);
+
+        $factory = new DoctrineEventStoreAdapterFactory();
+
+        $adapter = $factory($container->reveal());
+
+        $this->assertInstanceOf(DoctrineEventStoreAdapter::class, $adapter);
+    }
+
+    /**
+     * @test
+     */
+    public function it_creates_an_adapter_using_configured_connection_options()
+    {
+        $config['prooph']['event_store']['adapter']['options']['connection'] = [
+            'driver' => 'pdo_sqlite',
+            'dbname' => ':memory:'
+        ];
+
+        $container = $this->prophesize(ContainerInterface::class);
+
+        $container->has('config')->willReturn(true);
+        $container->get('config')->willReturn($config);
+        $container->has('app_dbal_connection')->willReturn(false);
+        $container->has(MessageFactory::class)->willReturn(false);
+        $container->has(MessageConverter::class)->willReturn(false);
+        $container->has(PayloadSerializer::class)->willReturn(false);
+
+        $factory = new DoctrineEventStoreAdapterFactory();
+
+        $adapter = $factory($container->reveal());
+
+        $this->assertInstanceOf(DoctrineEventStoreAdapter::class, $adapter);
+    }
+
+    /**
+     * @test
+     * @expectedException \Prooph\EventStore\Exception\ConfigurationException
+     */
+    public function it_throws_exception_if_adapter_options_are_not_available()
+    {
+        $config['prooph']['event_store']['adapter'] = [];
+
+        $container = $this->prophesize(ContainerInterface::class);
+
+        $container->has('config')->willReturn(true);
+        $container->get('config')->willReturn($config);
+
+        $factory = new DoctrineEventStoreAdapterFactory();
+        $factory($container->reveal());
+    }
+
+    /**
+     * @test
+     * @expectedException \Prooph\EventStore\Exception\ConfigurationException
+     */
+    public function it_throws_exception_if_adapter_connection_could_neither_be_located_nor_created()
+    {
+        $config['prooph']['event_store']['adapter']['options'] = [];
+
+        $container = $this->prophesize(ContainerInterface::class);
+
+        $container->has('config')->willReturn(true);
+        $container->get('config')->willReturn($config);
+
+        $factory = new DoctrineEventStoreAdapterFactory();
+        $factory($container->reveal());
+    }
+
+    /**
+     * @test
+     */
+    public function it_injects_helpers_from_container_if_available()
+    {
+        $messageFactory = $this->prophesize(MessageFactory::class);
+        $messageConverter = $this->prophesize(MessageConverter::class);
+        $payloadSerializer = $this->prophesize(PayloadSerializer::class);
+
+        $connection = $this->prophesize(Connection::class);
+
+        $config['prooph']['event_store']['adapter']['options']['connection_alias'] = 'app_dbal_connection';
+
+        $container = $this->prophesize(ContainerInterface::class);
+
+        $container->has('config')->willReturn(true);
+        $container->get('config')->willReturn($config);
+        $container->has('app_dbal_connection')->willReturn(true);
+        $container->get('app_dbal_connection')->willReturn($connection->reveal());
+        $container->has(MessageFactory::class)->willReturn(true);
+        $container->get(MessageFactory::class)->willReturn($messageFactory->reveal());
+        $container->has(MessageConverter::class)->willReturn(true);
+        $container->get(MessageConverter::class)->willReturn($messageConverter->reveal());
+        $container->has(PayloadSerializer::class)->willReturn(true);
+        $container->get(PayloadSerializer::class)->willReturn($payloadSerializer->reveal());
+
+        $factory = new DoctrineEventStoreAdapterFactory();
+
+        $adapter = $factory($container->reveal());
+
+        $this->assertAttributeSame($messageFactory->reveal(), 'messageFactory', $adapter);
+        $this->assertAttributeSame($messageConverter->reveal(), 'messageConverter', $adapter);
+        $this->assertAttributeSame($payloadSerializer->reveal(), 'payloadSerializer', $adapter);
+    }
+
+    /**
+     * @test
+     */
+    public function it_injects_stream_table_map_from_config()
+    {
+        $connection = $this->prophesize(Connection::class);
+
+        $config['prooph']['event_store']['adapter']['options']['connection_alias'] = 'app_dbal_connection';
+        $config['prooph']['event_store']['adapter']['options']['stream_table_map'] = ['A\Stream' => 'to_table'];
+
+        $container = $this->prophesize(ContainerInterface::class);
+
+        $container->has('config')->willReturn(true);
+        $container->get('config')->willReturn($config);
+        $container->has('app_dbal_connection')->willReturn(true);
+        $container->get('app_dbal_connection')->willReturn($connection->reveal());
+        $container->has(MessageFactory::class)->willReturn(false);
+        $container->has(MessageConverter::class)->willReturn(false);
+        $container->has(PayloadSerializer::class)->willReturn(false);
+
+        $factory = new DoctrineEventStoreAdapterFactory();
+
+        $adapter = $factory($container->reveal());
+
+        $this->assertEquals('to_table', $adapter->getTable(new StreamName('A\Stream')));
+    }
+}


### PR DESCRIPTION
See #2 

# Added
- `DoctrineEventStoreAdapterFactory` that works with a ``Interop\Container` to help you set up the adapter

# Changed
- The adapter now requires all dependencies in the constructor instead of a configuration array - BC Break
- The adapter now works with a `Prooph\Common\Messaging\MessageFactory` to translate persisted events back to event objects
- The adapter now works with a `Prooph\Common\Messaging\MessageConverter` to translate event object into PHP arrays
- The adapter now works with a `Prooph\EventStore\Adapter\PayloadSerializer` to serialize/unserialize event payload data

# Removed
- The table column `event_class` is no longer needed as the ``MessageFactory` is responsible of creating the correct event object based on the event name and event data
- Inheritance support is removed by adding the final keyword to the adapter class