### PR TITLE
Avoid rewind if not needed

### DIFF
--- a/src/DoctrineStreamIterator.php
+++ b/src/DoctrineStreamIterator.php
@@ -156,14 +156,17 @@ final class DoctrineStreamIterator implements Iterator
      */
     public function rewind()
     {
-        /* @var $stmt \Doctrine\DBAL\Statement */
-        $stmt = $this->queryBuilder->execute();
-        $stmt->setFetchMode(\PDO::FETCH_ASSOC);
+        //Only perform rewind if current item is not the first element
+        if ($this->currentKey !== 0) {
+            /* @var $stmt \Doctrine\DBAL\Statement */
+            $stmt = $this->queryBuilder->execute();
+            $stmt->setFetchMode(\PDO::FETCH_ASSOC);
 
-        $this->currentItem = null;
-        $this->currentKey = -1;
-        $this->statement = $stmt;
+            $this->currentItem = null;
+            $this->currentKey = -1;
+            $this->statement = $stmt;
 
-        $this->next();
+            $this->next();
+        }
     }
 }


### PR DESCRIPTION
Iterator::rewind is called each time the iterator
is passed to foreach which always causes a second
query even if the iterator is only looped once.
This PR adds a check to only rewind if current item
is not the first one.