### PR TITLE
require at least dbal 2.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     ],
     "require": {
         "php": ">=5.5",
-        "doctrine/dbal": "^2.4",
+        "doctrine/dbal": "^2.5",
         "beberlei/assert": "^2.0",
         "prooph/common": "^3.5",
         "container-interop/container-interop" : "~1.1"


### PR DESCRIPTION
Doctrine DBAL has a bug in 2.4 with PHP7, see: https://bugs.php.net/bug.php?id=70877