### PR TITLE
optimize database scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ The database structure depends on the [stream strategies](https://github.com/pro
 You can find example SQLs for MySql in the [scripts folder](scripts)
 and an [EventStoreSchema tool](src/Schema/EventStoreSchema.php) which you can use an a doctrine migrations scirpt.
 
+> The database schema is only a suggestion. The `aggregate_type` column has a length of 150 chars. If you have very 
+long class names you should increase this length, otherwise it could lead to errors in your application. This length
+should be equal with the `aggregate_type` length in the 
+[snapshot table](https://github.com/prooph/snapshot-doctrine-adapter "Doctrine Adapter for the Snapshot Store").
+
 Requirements
 ------------
 - PHP >= 5.5

--- a/scripts/mysql-aggregate-type-stream-template.sql
+++ b/scripts/mysql-aggregate-type-stream-template.sql
@@ -1,12 +1,12 @@
 -- Replace [shortclassname] with the lowercase short classname of your aggregate roots, e.g. My\Model\User = user = user_stream
 
 CREATE TABLE IF NOT EXISTS `[shortclassname]_stream` (
-  `event_id` varchar(36) COLLATE utf8_unicode_ci NOT NULL,
-  `version` int(11) NOT NULL,
+  `event_id` char(36) COLLATE utf8_unicode_ci NOT NULL,
+  `version` int(11) UNSIGNED NOT NULL,
   `event_name` varchar(100) COLLATE utf8_unicode_ci NOT NULL,
   `payload` text COLLATE utf8_unicode_ci NOT NULL,
-  `created_at` varchar(50) COLLATE utf8_unicode_ci NOT NULL,
-  `aggregate_id` text COLLATE utf8_unicode_ci NOT NULL,
-  `aggregate_type` varchar(100) COLLATE utf8_unicode_ci NOT NULL,
+  `created_at` char(26) COLLATE utf8_unicode_ci NOT NULL,
+  `aggregate_id` char(36) COLLATE utf8_unicode_ci NOT NULL,
+  `aggregate_type` varchar(150) COLLATE utf8_unicode_ci NOT NULL,
   PRIMARY KEY (`event_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;

--- a/scripts/mysql-single-stream-default-schema.sql
+++ b/scripts/mysql-single-stream-default-schema.sql
@@ -1,10 +1,10 @@
 CREATE TABLE IF NOT EXISTS `event_stream` (
-  `event_id` varchar(36) COLLATE utf8_unicode_ci NOT NULL,
-  `version` int(11) NOT NULL,
+  `event_id` char(36) COLLATE utf8_unicode_ci NOT NULL,
+  `version` int(11) UNSIGNED NOT NULL,
   `event_name` varchar(100) COLLATE utf8_unicode_ci NOT NULL,
   `payload` text COLLATE utf8_unicode_ci NOT NULL,
-  `created_at` varchar(50) COLLATE utf8_unicode_ci NOT NULL,
-  `aggregate_id` varchar(36) COLLATE utf8_unicode_ci NOT NULL,
-  `aggregate_type` varchar(100) COLLATE utf8_unicode_ci NOT NULL,
+  `created_at` char(26) COLLATE utf8_unicode_ci NOT NULL,
+  `aggregate_id` char(36) COLLATE utf8_unicode_ci NOT NULL,
+  `aggregate_type` varchar(150) COLLATE utf8_unicode_ci NOT NULL,
   PRIMARY KEY (`event_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;

--- a/src/Schema/EventStoreSchema.php
+++ b/src/Schema/EventStoreSchema.php
@@ -33,19 +33,30 @@ final class EventStoreSchema
     {
         $eventStream = $schema->createTable($streamName);
 
-        $eventStream->addColumn('event_id', 'string', ['length' => 36]);        //UUID of the event
-        $eventStream->addColumn('version', 'integer');                          //Version of the aggregate after event was recorded
-        $eventStream->addColumn('event_name', 'string', ['length' => 100]);     //Name of the event
-        $eventStream->addColumn('payload', 'text');                             //Event payload
-        $eventStream->addColumn('created_at', 'string', ['length' => 50]);      //DateTime ISO8601 + microseconds UTC stored as a string
-        $eventStream->addColumn('aggregate_id', 'string', ['length' => 36]);    //UUID of linked aggregate
-        $eventStream->addColumn('aggregate_type', 'string', ['length' => 100]); //Class of the linked aggregate
+        // UUID4 of the event
+        $eventStream->addColumn('event_id', 'string', ['fixed' => true, 'length' => 36]);
+        // Version of the aggregate after event was recorded
+        $eventStream->addColumn('version', 'integer', ['unsigned' => true]);
+        // Name of the event
+        $eventStream->addColumn('event_name', 'string', ['length' => 100]);
+        // Event payload
+        $eventStream->addColumn('payload', 'text');
+        // DateTime ISO8601 + microseconds UTC stored as a string e.g. 2016-02-02T11:45:39.000000
+        $eventStream->addColumn('created_at', 'string', ['fixed' => true, 'length' => 26]);
+        // UUID4 of linked aggregate
+        $eventStream->addColumn('aggregate_id', 'string', ['fixed' => true, 'length' => 36]);
+        // Class of the linked aggregate
+        $eventStream->addColumn('aggregate_type', 'string', ['length' => 150]);
+
         if ($withCausationColumns) {
-            $eventStream->addColumn('causation_id', 'string', ['length' => 36]);    //UUID of the command which caused the event
-            $eventStream->addColumn('causation_name', 'string', ['length' => 100]); //Name of the command which caused the event
+            // UUID4 of the command which caused the event
+            $eventStream->addColumn('causation_id', 'string', ['fixed' => true, 'length' => 36]);
+            // Name of the command which caused the event
+            $eventStream->addColumn('causation_name', 'string', ['length' => 100]);
         }
         $eventStream->setPrimaryKey(['event_id']);
-        $eventStream->addUniqueIndex(['aggregate_id', 'aggregate_type', 'version'], $streamName . '_m_v_uix'); //Concurrency check on database level
+        // Concurrency check on database level
+        $eventStream->addUniqueIndex(['aggregate_id', 'aggregate_type', 'version'], $streamName . '_m_v_uix');
     }
 
     /**
@@ -59,19 +70,30 @@ final class EventStoreSchema
     {
         $eventStream = $schema->createTable($streamName);
 
-        $eventStream->addColumn('event_id', 'string', ['length' => 36]);        //UUID of the event
-        $eventStream->addColumn('version', 'integer');                          //Version of the aggregate after event was recorded
-        $eventStream->addColumn('event_name', 'string', ['length' => 100]);     //Name of the event
-        $eventStream->addColumn('payload', 'text');                             //Event payload
-        $eventStream->addColumn('created_at', 'string', ['length' => 50]);      //DateTime ISO8601 + microseconds UTC stored as a string
-        $eventStream->addColumn('aggregate_id', 'string', ['length' => 36]);    //UUID of linked aggregate
-        $eventStream->addColumn('aggregate_type', 'string', ['length' => 100]); //Class of the linked aggregate
+        // UUID4 of the event
+        $eventStream->addColumn('event_id', 'string', ['fixed' => true, 'length' => 36]);
+        // Version of the aggregate after event was recorded
+        $eventStream->addColumn('version', 'integer', ['unsigned' => true]);
+        // Name of the event
+        $eventStream->addColumn('event_name', 'string', ['length' => 100]);
+        // Event payload
+        $eventStream->addColumn('payload', 'text');
+        // DateTime ISO8601 + microseconds UTC stored as a string e.g. 2016-02-02T11:45:39.000000
+        $eventStream->addColumn('created_at', 'string', ['fixed' => true, 'length' => 26]);
+        // UUID4 of linked aggregate
+        $eventStream->addColumn('aggregate_id', 'string', ['fixed' => true, 'length' => 36]);
+        // Class of the linked aggregate
+        $eventStream->addColumn('aggregate_type', 'string', ['length' => 150]);
+
         if ($withCausationColumns) {
-            $eventStream->addColumn('causation_id', 'string', ['length' => 36]);    //UUID of the command which caused the event
-            $eventStream->addColumn('causation_name', 'string', ['length' => 100]); //Name of the command which caused the event
+            // UUID4 of the command which caused the event
+            $eventStream->addColumn('causation_id', 'string', ['fixed' => true, 'length' => 36]);
+            // Name of the command which caused the event
+            $eventStream->addColumn('causation_name', 'string', ['length' => 100]);
         }
         $eventStream->setPrimaryKey(['event_id']);
-        $eventStream->addUniqueIndex(['aggregate_id', 'version'], $streamName . '_m_v_uix'); //Concurrency check on database level
+        // Concurrency check on database level
+        $eventStream->addUniqueIndex(['aggregate_id', 'version'], $streamName . '_m_v_uix');
     }
 
     /**

--- a/tests/Schema/EventStoreSchemaTest.php
+++ b/tests/Schema/EventStoreSchemaTest.php
@@ -55,7 +55,7 @@ final class EventStoreSchemaTest extends TestCase
 
         $this->assertTrue($table->hasColumn('created_at'));
         $this->assertInstanceOf(StringType::class, $table->getColumn('created_at')->getType());
-        $this->assertEquals(50, $table->getColumn('created_at')->getLength());
+        $this->assertEquals(26, $table->getColumn('created_at')->getLength());
 
         $this->assertTrue($table->hasColumn('aggregate_id'));
         $this->assertInstanceOf(StringType::class, $table->getColumn('aggregate_id')->getType());
@@ -63,7 +63,7 @@ final class EventStoreSchemaTest extends TestCase
 
         $this->assertTrue($table->hasColumn('aggregate_type'));
         $this->assertInstanceOf(StringType::class, $table->getColumn('aggregate_type')->getType());
-        $this->assertEquals(100, $table->getColumn('aggregate_type')->getLength());
+        $this->assertEquals(150, $table->getColumn('aggregate_type')->getLength());
 
         $this->assertEquals(['event_id'], $table->getPrimaryKey()->getColumns());
 
@@ -154,7 +154,7 @@ final class EventStoreSchemaTest extends TestCase
 
         $this->assertTrue($table->hasColumn('created_at'));
         $this->assertInstanceOf(StringType::class, $table->getColumn('created_at')->getType());
-        $this->assertEquals(50, $table->getColumn('created_at')->getLength());
+        $this->assertEquals(26, $table->getColumn('created_at')->getLength());
 
         $this->assertTrue($table->hasColumn('aggregate_id'));
         $this->assertInstanceOf(StringType::class, $table->getColumn('aggregate_id')->getType());
@@ -162,7 +162,7 @@ final class EventStoreSchemaTest extends TestCase
 
         $this->assertTrue($table->hasColumn('aggregate_type'));
         $this->assertInstanceOf(StringType::class, $table->getColumn('aggregate_type')->getType());
-        $this->assertEquals(100, $table->getColumn('aggregate_type')->getLength());
+        $this->assertEquals(150, $table->getColumn('aggregate_type')->getLength());
 
         $this->assertFalse($table->hasColumn('causation_id'));
 


### PR DESCRIPTION
This uses the most optimized available type of the column.

Has the DateTime ISO8601 + microseconds UTC format always a **length of 26** or why was it 50? The `aggregate_id` length was also set to 36 (UUID4).

Note: I think there is no major release necessary. Because columns are the same and nothing happens if the migration already exists.