### PR TITLE
update factories to interop-config 1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     },
     "require-dev": {
         "container-interop/container-interop": "^1.1",
-        "sandrokeil/interop-config": "^0.3",
+        "sandrokeil/interop-config": "^1.0",
         "phpunit/phpunit": "4.8.*",
         "fabpot/php-cs-fixer": "1.7.*",
         "satooshi/php-coveralls": "dev-master"
@@ -36,6 +36,9 @@
     "suggest": {
         "container-interop/container-interop": "For usage of provided factories",
         "sandrokeil/interop-config": "For usage of provided factories"
+    },
+    "conflict": {
+        "sandrokeil/interop-config": "<1.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Container/DoctrineEventStoreAdapterFactory.php
+++ b/src/Container/DoctrineEventStoreAdapterFactory.php
@@ -36,17 +36,9 @@ final class DoctrineEventStoreAdapterFactory implements RequiresConfig, Requires
     /**
      * @inheritdoc
      */
-    public function vendorName()
+    public function dimensions()
     {
-        return 'prooph';
-    }
-
-    /**
-     * @inheritdoc
-     */
-    public function packageName()
-    {
-        return 'event_store';
+        return ['prooph', 'event_store'];
     }
 
     /**


### PR DESCRIPTION
Not sure if it makes sense to add config id support, because of some discussions in the Gitter channel for multiple event stores? 

/cc @codeliner 