### PR TITLE
add concurrency exception

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     ],
     "require": {
         "php": "~5.5|~7.0",
-        "prooph/event-store": "^6.2",
+        "prooph/event-store": "^6.3",
         "doctrine/dbal": "^2.5",
         "beberlei/assert": "^2.3",
         "prooph/common": "^3.7"

--- a/src/Schema/EventStoreSchema.php
+++ b/src/Schema/EventStoreSchema.php
@@ -56,7 +56,7 @@ final class EventStoreSchema
         }
         $eventStream->setPrimaryKey(['event_id']);
         // Concurrency check on database level
-        $eventStream->addUniqueIndex(['aggregate_id', 'aggregate_type', 'version'], $streamName . '_m_v_uix');
+        $eventStream->addUniqueIndex(['aggregate_id', 'version'], $streamName . '_m_v_uix');
     }
 
     /**

--- a/tests/DoctrineEventStoreAdapterTest.php
+++ b/tests/DoctrineEventStoreAdapterTest.php
@@ -407,6 +407,33 @@ class DoctrineEventStoreAdapterTest extends TestCase
     }
 
     /**
+     * @test
+     * @expectedException \Prooph\EventStore\Exception\ConcurrencyException
+     */
+    public function it_fails_to_write_with_duplicate_aggregate_id_and_version()
+    {
+        $streamEvent = UserCreated::with(
+            ['name' => 'Max Mustermann', 'email' => 'contact@prooph.de'],
+            1
+        );
+
+        $streamEvent = $streamEvent->withAddedMetadata('aggregate_id', 'one');
+        $streamEvent = $streamEvent->withAddedMetadata('aggregate_type', 'user');
+
+        $this->adapter->create(new Stream(new StreamName('Prooph\Model\User'), new \ArrayIterator([$streamEvent])));
+
+        $streamEvent = UsernameChanged::with(
+            ['name' => 'John Doe'],
+            1
+        );
+
+        $streamEvent = $streamEvent->withAddedMetadata('aggregate_id', 'one');
+        $streamEvent = $streamEvent->withAddedMetadata('aggregate_type', 'user');
+
+        $this->adapter->appendTo(new StreamName('Prooph\Model\User'), new \ArrayIterator([$streamEvent]));
+    }
+
+    /**
      * @return Stream
      */
     private function getTestStream()

--- a/tests/Schema/EventStoreSchemaTest.php
+++ b/tests/Schema/EventStoreSchemaTest.php
@@ -68,7 +68,7 @@ final class EventStoreSchemaTest extends TestCase
         $this->assertEquals(['event_id'], $table->getPrimaryKey()->getColumns());
 
         $this->assertTrue($table->hasIndex('event_stream_m_v_uix'));
-        $this->assertEquals(['aggregate_id', 'aggregate_type', 'version'], $table->getIndex('event_stream_m_v_uix')->getColumns());
+        $this->assertEquals(['aggregate_id', 'version'], $table->getIndex('event_stream_m_v_uix')->getColumns());
     }
 
     /**
@@ -85,7 +85,7 @@ final class EventStoreSchemaTest extends TestCase
         $this->assertEquals('custom_stream', $table->getName());
 
         $this->assertTrue($table->hasIndex('custom_stream_m_v_uix'));
-        $this->assertEquals(['aggregate_id', 'aggregate_type', 'version'], $table->getIndex('custom_stream_m_v_uix')->getColumns());
+        $this->assertEquals(['aggregate_id', 'version'], $table->getIndex('custom_stream_m_v_uix')->getColumns());
     }
 
     /**


### PR DESCRIPTION
related to: https://github.com/prooph/event-store/pull/173

also fixes bug to automatically add unique constraint index when aggregate_id field is part of the event metadata.