### PR TITLE
fixes unit test which creates two events with same version

### DIFF
--- a/tests/DoctrineEventStoreAdapterTest.php
+++ b/tests/DoctrineEventStoreAdapterTest.php
@@ -125,7 +125,7 @@ class DoctrineEventStoreAdapterTest extends TestCase
 
         $streamEvent2 = UsernameChanged::with(
             ['name' => 'Jane Doe'],
-            2
+            3
         );
 
         $streamEvent2 = $streamEvent2->withAddedMetadata('tag', 'person');


### PR DESCRIPTION
That unit test ran also without this fix.
But i reckon the use of version "2" instead of "3" was a c/p mistake, since an equal test from mongodb adapter uses version "3" here to.
